### PR TITLE
add meta viewpoint to head of html to avoid zoom on mobile devices

### DIFF
--- a/game.html
+++ b/game.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>2x2 Grid Example</title>  
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <style>    
     .wordlist-pressed { /* 11/9/23 was going to use .wordlist-selector-button:focus but that only 'presses' one button */
       background-color: green;


### PR DESCRIPTION
meta tag added to the head of game.html to stop auto zooming when vertical clues are clicked on mobile device